### PR TITLE
https://skillsfundingagency.atlassian.net/browse/SDD-264

### DIFF
--- a/DFC.Swagger.Standard/SwaggerDocumentGenerator.cs
+++ b/DFC.Swagger.Standard/SwaggerDocumentGenerator.cs
@@ -529,7 +529,7 @@ namespace DFC.Swagger.Standard
             }
             else if (isEnum || isNullableEnum)
             {
-                opParam.type = "string";
+                opParam.type = "int32";
                 var enumValues = new List<string>();
 
                 if (isEnum)


### PR DESCRIPTION
Fixed the swagger doc so that Enum's are displayed as type Int32 and not string