### PR TITLE
NCSLT-58 [dfc-swagger...//] make subcontractor mandatory

### DIFF
--- a/DFC.Swagger.Standard/SwaggerDocumentGenerator.cs
+++ b/DFC.Swagger.Standard/SwaggerDocumentGenerator.cs
@@ -271,7 +271,7 @@ namespace DFC.Swagger.Standard
                 opHeaderParam2.name = "SubcontractorId";
                 opHeaderParam2.description = "The subcontractor id";
                 opHeaderParam2.@in = "header";
-                opHeaderParam2.required = false;
+                opHeaderParam2.required = true;
                 opHeaderParam2.type = "string";
                 parameterSignatures.Add(opHeaderParam2);
             }


### PR DESCRIPTION
only an interface change to the APIM, no logical changes at all. All logic added from this ticket was done in the DSS repos directly and not in this swagger doc.